### PR TITLE
Implement Elm 0.19's changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ elm-stuff
 index.js
 index.html
 node_modules
+tests/Doc

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ index.js
 index.html
 node_modules
 tests/Doc
+elm.js

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Code from version 4 of Elm's "core" library is licensed as follows:
+Code from Elm's libraries is licensed as follows:
 
 Copyright (c) 2014-present, Evan Czaplicki
 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,26 @@
 
 # elm-compat-018
 
-This is a module for Elm 0.18 which allows you to use some of the things in Elm
-0.17's [`elm-lang/core`](http://package.elm-lang.org/packages/elm-lang/core/4.0.0)
-which were changed in Elm 0.18.
+This is a package for Elm 0.18 that allows you to reach into Elm's past and
+Elm's future.
 
-It should be said that the best way to experience all the goodness of Elm 0.18
-is to actually modify your projects to use Elm 0.18's version of these changes.
-And [elm-format](https://github.com/avh4/elm-format) has some nice features to
-help you do that easily.
+- You can use some of the old things from Elm 0.17's
+[`elm-lang/core`](http://package.elm-lang.org/packages/elm-lang/core/4.0.0)
+which were changed or dropped in Elm 0.18. Now, the best way to experience all
+the goodness of Elm 0.18 is to actually modify your code. However, there are
+cases in which you might want to keep using some "retro" features of Elm 0.17.
+Perhaps they are handy for your particular scenario, or perhaps you are
+maintaining some code that you need to compile in multiple versions of Elm.
 
-However, there are cases in which you might want to keep using some "retro"
-features of Elm 0.17. Perhaps they are handy for your particular scenario, or
-perhaps you are maintaining some code that you need to compile in multiple
-versions of Elm.
+- You can use some of the new things in Elm 0.19's
+[`elm/core`](https://package.elm-lang.org/packages/elm/core/1.0.0).  Now, the
+best way to experience all of the goodness of Elm 0.19 is to upgrade your code.
+However, there are cases in which you don't want to upgrade to the latest
+version of Elm, but would find it handy to use some of its features. For
+instance, you may have an app in production, or you may have code that you need
+to compile with multiple versions of Elm.
 
-So, this library may be of some assistance in those cases.
+So, this package may be of some assistance in those scenarios.
 
 ## API
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -11,6 +11,7 @@
         "Basics019",
         "Bitwise017",
         "Char019",
+        "Debug019",
         "Json.Decode017",
         "Maybe017",
         "Random017",

--- a/elm-package.json
+++ b/elm-package.json
@@ -14,6 +14,7 @@
         "Debug019",
         "Json.Decode017",
         "Maybe017",
+        "Platform019",
         "Random017",
         "Random19",
         "Result017",

--- a/elm-package.json
+++ b/elm-package.json
@@ -8,12 +8,16 @@
     ],
     "exposed-modules": [
         "Basics017",
+        "Basics019",
         "Bitwise017",
+        "Char019",
         "Json.Decode017",
         "Maybe017",
         "Random017",
+        "Random19",
         "Result017",
-        "Task017"
+        "Task017",
+        "Time019"
     ],
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",

--- a/elm-package.json
+++ b/elm-package.json
@@ -19,6 +19,7 @@
         "Random019",
         "Regex019",
         "Result017",
+        "String019",
         "Task017",
         "Time019"
     ],

--- a/elm-package.json
+++ b/elm-package.json
@@ -21,7 +21,8 @@
         "Result017",
         "String019",
         "Task017",
-        "Time019"
+        "Time019",
+        "Tuple019"
     ],
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",

--- a/elm-package.json
+++ b/elm-package.json
@@ -16,7 +16,8 @@
         "Maybe017",
         "Platform019",
         "Random017",
-        "Random19",
+        "Random019",
+        "Regex019",
         "Result017",
         "Task017",
         "Time019"

--- a/elm-package.json
+++ b/elm-package.json
@@ -16,7 +16,8 @@
         "Task017"
     ],
     "dependencies": {
-        "elm-lang/core": "5.0.0 <= v < 6.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "justinmimbs/elm-date-extra": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -13,6 +13,7 @@
         "Char019",
         "Debug019",
         "Json.Decode017",
+        "Json.Encode019",
         "Maybe017",
         "Platform019",
         "Random017",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "dependencies": {},
   "devDependencies": {
     "elm": "^0.18.0",
-    "elm-test": "^0.18.3"
+    "elm-test": "^0.18.3",
+    "elm-doc-test": "^4.0.0"
   },
   "scripts": {
-    "test": "elm-test"
+    "test": "elm-doc-test && elm-test"
   },
   "repository": {
     "type": "git",

--- a/src/Basics019.elm
+++ b/src/Basics019.elm
@@ -1,0 +1,56 @@
+module Basics019 exposing (modBy, remainderBy)
+
+{-| Elm 0.19 renamed these two functions, so here they are with their
+new names.
+
+@docs modBy, remainderBy
+
+-}
+
+
+{-| Perform [modular arithmetic](https://en.wikipedia.org/wiki/Modular_arithmetic).
+A common trick is to use (n mod 2) to detect even and odd numbers:
+
+    modBy 2 0 --> 0
+
+    modBy 2 1 --> 1
+
+    modBy 2 2 --> 0
+
+    modBy 2 3 --> 1
+
+Our `modBy` function works in the typical mathematical way when you run into
+negative numbers:
+
+    List.map (modBy 4)
+        [ -5, -4, -3, -2, -1,  0,  1,  2,  3,  4,  5 ]
+        --> [  3,  0,  1,  2,  3,  0,  1,  2,  3,  0,  1 ]
+
+Use [`remainderBy`](#remainderBy) for a different treatment of negative numbers,
+or read Daan Leijen’s [Division and Modulus for Computer Scientists][dm] for more
+information.
+
+[dm]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/divmodnote-letter.pdf
+
+-}
+modBy : Int -> Int -> Int
+modBy =
+    flip (%)
+
+
+{-| Get the remainder after division. Here are bunch of examples of dividing by four:
+
+    List.map (remainderBy 4)
+        [ -5, -4, -3, -2, -1,  0,  1,  2,  3,  4,  5 ]
+        --> [ -1,  0, -3, -2, -1,  0,  1,  2,  3,  0,  1 ]
+
+Use [`modBy`](#modBy) for a different treatment of negative numbers,
+or read Daan Leijen’s [Division and Modulus for Computer Scientists][dm] for more
+information.
+
+[dm]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/divmodnote-letter.pdf
+
+-}
+remainderBy : Int -> Int -> Int
+remainderBy =
+    flip rem

--- a/src/Char019.elm
+++ b/src/Char019.elm
@@ -1,0 +1,55 @@
+module Char019 exposing (isAlpha, isAlphaNum)
+
+{-| Elm 0.19 added a few new functions.
+
+@docs isAlpha, isAlphaNum
+
+-}
+
+import Char exposing (isDigit, isLower, isUpper)
+
+
+{-| Detect upper case and lower case ASCII characters.
+
+    isAlpha 'a' --> True
+
+    isAlpha 'b' --> True
+
+    isAlpha 'E' --> True
+
+    isAlpha 'Y' --> True
+
+    isAlpha '0' --> False
+
+    isAlpha '-' --> False
+
+    isAlpha 'π' --> False
+
+-}
+isAlpha : Char -> Bool
+isAlpha char =
+    isLower char || isUpper char
+
+
+{-| Detect upper case and lower case ASCII characters.
+
+    isAlphaNum 'a' --> True
+
+    isAlphaNum 'b' --> True
+
+    isAlphaNum 'E' --> True
+
+    isAlphaNum 'Y' --> True
+
+    isAlphaNum '0' --> True
+
+    isAlphaNum '7' --> True
+
+    isAlphaNum '-' --> False
+
+    isAlphaNum 'π' --> False
+
+-}
+isAlphaNum : Char -> Bool
+isAlphaNum char =
+    isLower char || isUpper char || isDigit char

--- a/src/Debug019.elm
+++ b/src/Debug019.elm
@@ -1,0 +1,61 @@
+module Debug019 exposing (toString, todo)
+
+{-| Elm 0.19 moved `toString` to the `Debug` module, and renamed
+`crash` to `todo`.
+
+@docs toString, todo
+
+-}
+
+
+{-| Turn any kind of value into a string.
+
+    Debug019.toString 42                --> "42"
+
+    Debug019.toString [1,2]             --> "[1,2]"
+
+    Debug019.toString ('a', "cat", 13)  --> "('a',\"cat\",13)"
+
+    Debug019.toString "he said, \"hi\"" --> "\"he said, \\\"hi\\\"\""
+
+Notice that with strings, this is not the `identity` function. It escapes
+characters so if you say `Html.text (toString "he said, \"hi\"")` it will
+show `"he said, \"hi\""` rather than `he said, "hi"`. This makes it nice
+for viewing Elm data structures.
+
+-}
+toString : a -> String
+toString =
+    Basics.toString
+
+
+{-| This is a placeholder for code that you will write later.
+
+For example, if you are working with a large union type and have partially
+completed a case expression, it may make sense to do this:
+
+    type Entity = Ship | Fish | Captain | Seagull
+
+    drawEntity entity =
+      case entity of
+        Ship ->
+          ...
+
+        Fish ->
+          ...
+
+        _ ->
+          Debug.todo "handle Captain and Seagull"
+
+The Elm compiler recognizes each `Debug.todo` so if you run into it, you get
+an **uncatchable runtime exception** that includes the module name and line
+number.
+
+**Note:** For the equivalent of try/catch error handling in Elm, use modules
+like [`Maybe`](#Maybe) and [`Result`](#Result) which guarantee that no error
+goes unhandled!
+
+-}
+todo : String -> a
+todo =
+    Debug.crash

--- a/src/Json/Encode019.elm
+++ b/src/Json/Encode019.elm
@@ -1,0 +1,48 @@
+module Json.Encode019 exposing (dict, set)
+
+{-| Elm 0.19 moved this module to a separate package, and added
+a couple of new encoders.
+
+@docs dict, set
+
+-}
+
+import Dict exposing (Dict)
+import Json.Encode exposing (Value, object, list)
+import Set exposing (Set)
+
+
+{-| Turn a `Dict` into a JSON object.
+
+    import Dict
+    import Json.Encode as Encode
+
+    Dict.fromList [ ("Tom",42), ("Sue", 38) ]
+        |> dict identity Encode.int
+        |> Encode.encode 0
+        --> """{"Tom":42,"Sue":38}"""
+
+-}
+dict : (comparable -> String) -> (v -> Value) -> Dict comparable v -> Value
+dict toKey toValue =
+    let
+        go key value accum =
+            ( toKey key, toValue value ) :: accum
+    in
+        Dict.foldl go [] >> object
+
+
+{-| Turn an `Set` into a JSON array.
+
+    import Json.Encode as Encode
+    import Set
+
+    Set.fromList [ 42, 38 ]
+        |> set Encode.int
+        |> Encode.encode 0
+        --> "[38,42]"
+
+-}
+set : (comparable -> Value) -> Set comparable -> Value
+set func =
+    Set.toList >> List.map func >> list

--- a/src/Platform019.elm
+++ b/src/Platform019.elm
@@ -1,0 +1,33 @@
+module Platform019 exposing (worker)
+
+{-| In Elm 0.19, `programWithFlags` was renamed `worker`.
+-}
+
+import Platform exposing (Program, programWithFlags)
+
+
+{-| Create a [headless] program with no user interface.
+
+This is great if you want to use Elm as the &ldquo;brain&rdquo; for something
+else. For example, you could send messages out ports to modify the DOM, but do
+all the complex logic in Elm.
+
+[headless]: https://en.wikipedia.org/wiki/Headless_software
+
+Initializing a headless program from JavaScript looks like this:
+
+```javascript
+var app = Elm.MyThing.init();
+```
+
+[headless]: https://en.wikipedia.org/wiki/Headless_software
+
+-}
+worker :
+    { init : flags -> ( model, Cmd msg )
+    , update : msg -> model -> ( model, Cmd msg )
+    , subscriptions : model -> Sub msg
+    }
+    -> Program flags model msg
+worker =
+    programWithFlags

--- a/src/Random019.elm
+++ b/src/Random019.elm
@@ -1,0 +1,203 @@
+module Random019 exposing (constant, independentSeed, lazy, uniform, weighted)
+
+{-| Elm 0.19 moved `Random` to a separate module and added several functions
+to the API. Those functions are provided here.
+
+Elm 0.19 also improved the basic algorithm for randomness. That is not
+implemented here -- so, this is the Elm 0.18 algorithm with the Elm 0.19 API.
+If you want something closer to the Elm 0.19 algorithm in Elm 0.18, then
+consider using
+[mgold/elm-random-pcg](https://package.elm-lang.org/packages/mgold/elm-random-pcg/latest)
+
+@docs uniform, weighted, constant, lazy, independentSeed
+
+-}
+
+import Bitwise
+import Random exposing (..)
+
+
+{-| Generate the same value every time.
+
+    import Random
+
+    alwaysFour : Random.Generator Int
+    alwaysFour =
+        Random.constant 4
+
+Think of it as picking from a hat with only one thing in it. It is weird,
+but it can be useful with [`elm-community/random-extra`][extra] which has
+tons of nice helpers.
+
+[extra]: /packages/elm-community/random-extra/latest
+
+-}
+constant : a -> Generator a
+constant value =
+    map (always value) bool
+
+
+{-| Generate values with equal probability. Say we want a random suit for some
+cards:
+
+    import Random
+
+    type Suit
+        = Diamond
+        | Club
+        | Heart
+        | Spade
+
+    suit : Random.Generator Suit
+    suit =
+        Random.uniform Diamond [ Club, Heart, Spade ]
+
+That generator produces all `Suit` values with equal probability, 25% each.
+
+**Note:** Why not have `uniform : List a -> Generator a` as the API? It looks
+a little prettier in code, but it leads to an awkward question. What do you do
+with `uniform []`? How can it produce an `Int` or `Float`? The current API
+guarantees that we always have _at least_ one value, so we never run into that
+question!
+
+-}
+uniform : a -> List a -> Generator a
+uniform value valueList =
+    weighted (addOne value) (List.map addOne valueList)
+
+
+addOne : a -> ( Float, a )
+addOne value =
+    ( 1, value )
+
+
+{-| Generate values with a _weighted_ probability. Say we want to simulate a
+[loaded die](https://en.wikipedia.org/wiki/Dice#Loaded_dice) that lands
+on ⚄ and ⚅ more often than the other faces:
+
+    import Random
+
+    type Face
+        = One
+        | Two
+        | Three
+        | Four
+        | Five
+        | Six
+
+    roll : Random.Generator Face
+    roll =
+        Random.weighted
+            ( 10, One )
+            [ ( 10, Two )
+            , ( 10, Three )
+            , ( 10, Four )
+            , ( 20, Five )
+            , ( 40, Six )
+            ]
+
+So there is a 40% chance of getting `Six`, a 20% chance of getting `Five`, and
+then a 10% chance for each of the remaining faces.
+
+**Note:** I made the weights add up to 100, but that is not necessary. I always
+add up your weights into a `total`, and from there, the probablity of each case
+is `weight / total`. Negative weights do not really make sense, so I just flip
+them to be positive.
+
+-}
+weighted : ( Float, a ) -> List ( Float, a ) -> Generator a
+weighted first others =
+    let
+        normalize ( weight, _ ) =
+            abs weight
+
+        total =
+            normalize first + List.sum (List.map normalize others)
+    in
+    map (getByWeight first others) (float 0 total)
+
+
+getByWeight : ( Float, a ) -> List ( Float, a ) -> Float -> a
+getByWeight ( weight, value ) others countdown =
+    case others of
+        [] ->
+            value
+
+        second :: otherOthers ->
+            if countdown <= abs weight then
+                value
+            else
+                getByWeight second otherOthers (countdown - abs weight)
+
+
+{-| Helper for defining self-recursive generators. Say we want to generate a
+random number of probabilities:
+
+    import Random
+
+    probabilities : Random.Generator (List Float)
+    probabilities =
+        Random.andThen identity <|
+            Random.uniform
+                (Random.constant [])
+                [ Random.map2 (::)
+                    (Random.float 0 1)
+                    (Random.lazy (\_ -> probabilities))
+                ]
+
+In 50% of cases we end the list. In 50% of cases we generate a probability and
+add it onto a random number of probabilities. The `lazy` call is crucial
+because it means we do not unroll the generator unless we need to.
+
+This is a pretty subtle issue, so I recommend reading more about it
+[here](https://elm-lang.org/hints/0.19.0/bad-recursion)!
+
+**Note:** You can delay evaluation with `andThen` too. The thing that matters
+is that you have a function call that delays the creation of the generator!
+
+-}
+lazy : (() -> Generator a) -> Generator a
+lazy callback =
+    andThen callback (constant ())
+
+
+{-| A generator that produces a seed that is independent of any other seed in
+the program. These seeds will generate their own unique sequences of random
+values. They are useful when you need an unknown amount of randomness _later_
+but can request only a fixed amount of randomness _now_.
+
+> It does not seem possible to implement Elm 0.19's exact algorithm in an Elm
+> 0.18 user package. So, what is implemented here is an approximation of what Elm
+> 0.19 does, and probably does not have the same quality of randomness.
+
+-}
+independentSeed : Generator Seed
+independentSeed =
+    -- The Elm 0.19 implementation relies on the internal properties of seeds,
+    -- so we can't implement it quite the same way here. So, we try something
+    -- that is roughly sinilar, but may or may not work as well.
+    --
+    -- 1. We generate two integers using our current seed. This advances the
+    --    current seed (which you might call the "main" seed).
+    --
+    -- 2. We xor the two random integers together, and use the result to produce an
+    --    `initialSeed`. (Elm 0.19's code also makes sure it is a positive odd
+    --    number, but that's because they are working directly with the seed
+    --    value, rather than going through `initialSeed`).
+    --
+    -- So, we end up with a new seed (you might call it a "forked" seed), and
+    -- an updated "main" seed. Thus, if you do this again with the updated
+    -- "main" seed, you should get a distinct "forked" seed the second time.
+    --
+    -- This is a bit simpler than the Elm 0.19 implementation, but it ought to
+    -- work at some level. It probably does not produce the same quality of
+    -- randomness that the Elm 0.19 implementation achieves (since the Elm 0.19
+    -- implementation could be much simpler if it did).
+    let
+        gen =
+            int 0 0xFFFFFFFF
+
+        makeIndependentSeed a b =
+            initialSeed (Bitwise.xor a b)
+    in
+    map2 makeIndependentSeed gen gen

--- a/src/Regex019.elm
+++ b/src/Regex019.elm
@@ -1,0 +1,208 @@
+module Regex019 exposing (Options, find, findAtMost, fromString, fromStringWith, never, split, splitAtMost)
+
+{-| `Regex` was moved to a separate package in Elm 0.19, and the
+API had some significant changes. Those changes are back-ported here, so much
+as is possible.
+
+@docs fromString, fromStringWith, Options, never
+
+@docs split, splitAtMost, find, findAtMost
+
+-}
+
+import Regex exposing (HowMany(..), Match, Regex, caseInsensitive, regex)
+
+
+{-| Try to create a `Regex`.
+
+    import Regex
+
+    lowerCase : Regex.Regex
+    lowerCase =
+        Maybe.withDefault Regex.never <|
+            Regex.fromString "[a-z]+"
+
+**Note:** There are some [shorthand character classes][short] like `\w` for
+word characters, `\s` for whitespace characters, and `\d` for digits. **Make
+sure they are properly escaped!** If you specify them directly in your code,
+they would look like `"\\w\\s\\d"`.
+
+[short]: https://www.regular-expressions.info/shorthand.html
+
+> In Elm 0.19, this returns a `Maybe` in order to cover cases where the
+> input is not a valid regular expression. It is not practical to port this
+> behaviour back to Elm 0.18, so we always return `Just ...`, and crash if
+> the input is not valid (as Elm 0.18 would do).
+
+-}
+fromString : String -> Maybe Regex
+fromString =
+    regex >> Just
+
+
+{-| Create a `Regex` with some additional options. For example, you can define
+`fromString` like this:
+
+    import Regex
+
+    fromString : String -> Maybe Regex.Regex
+    fromString string =
+        fromStringWith { caseInsensitive = False } string
+
+> In Elm 0.19, there is also a `multiline` option, but it is not practical
+> to back-port this option to Elm 0.18.
+
+-}
+fromStringWith : Options -> String -> Maybe Regex
+fromStringWith options =
+    let
+        applyOptions =
+            if options.caseInsensitive then
+                caseInsensitive
+            else
+                identity
+    in
+    Maybe.map applyOptions << fromString
+
+
+{-| This type was introduced in Elm 0.19. In Elm 0.19, it also has a
+`multiline` field, but it is not practical to back-port that behaviour
+to Elm 0.18.
+-}
+type alias Options =
+    { caseInsensitive : Bool
+    }
+
+
+{-| A regular expression that never matches any string.
+-}
+never : Regex
+never =
+    regex ".^"
+
+
+{-| Split a string. The following example will split on commas and tolerate
+whitespace on either side of the comma:
+
+    import Regex
+
+    comma : Regex.Regex
+    comma =
+        Maybe.withDefault Regex.never <|
+            Regex.fromString " *, *"
+
+
+    -- Regex.split comma "tom,99,90,85"     == ["tom","99","90","85"]
+    -- Regex.split comma "tom, 99, 90, 85"  == ["tom","99","90","85"]
+    -- Regex.split comma "tom , 99, 90, 85" == ["tom","99","90","85"]
+
+If you want some really fancy splits, a library like
+[`elm/parser`][parser] will probably be easier to use.
+
+[parser]: /packages/elm/parser/latest
+
+-}
+split : Regex -> String -> List String
+split =
+    Regex.split All
+
+
+{-| Just like `split` but it stops after some number of matches.
+
+A library like [`elm/parser`][parser] will probably lead to better code in
+the long run.
+
+[parser]: /packages/elm/parser/latest
+
+-}
+splitAtMost : Int -> Regex -> String -> List String
+splitAtMost =
+    Regex.split << AtMost
+
+
+{-| Find matches in a string:
+
+    import Regex
+
+    location : Regex.Regex
+    location =
+        Maybe.withDefault Regex.never <|
+            Regex.fromString "[oi]n a (\\w+)"
+
+    places : List Regex.Match
+    places =
+        Regex.find location "I am on a boat in a lake."
+
+
+    -- map .match      places == [ "on a boat", "in a lake" ]
+    -- map .submatches places == [ [Just "boat"], [Just "lake"] ]
+
+If you need `submatches` for some reason, a library like
+[`elm/parser`][parser] will probably lead to better code in the long run.
+
+[parser]: /packages/elm/parser/latest
+
+-}
+find : Regex -> String -> List Match
+find =
+    Regex.find All
+
+
+{-| Just like `find` but it stops after some number of matches.
+
+A library like [`elm/parser`][parser] will probably lead to better code in
+the long run.
+
+[parser]: /packages/elm/parser/latest
+
+-}
+findAtMost : Int -> Regex -> String -> List Match
+findAtMost =
+    Regex.find << AtMost
+
+
+{-| Replace matches. The function from `Match` to `String` lets
+you use the details of a specific match when making replacements.
+
+    import Regex
+
+    userReplace : String -> (Regex.Match -> String) -> String -> String
+    userReplace userRegex replacer string =
+        case Regex.fromString userRegex of
+            Nothing ->
+                string
+
+            Just regex ->
+                Regex.replace regex replacer string
+
+    devowel : String -> String
+    devowel string =
+        userReplace "[aeiou]" (\_ -> "") string
+
+
+    -- devowel "The quick brown fox" == "Th qck brwn fx"
+
+    reverseWords : String -> String
+    reverseWords string =
+        userReplace "\\w+" (.match >> String.reverse) string
+
+
+    -- reverseWords "deliver mined parts" == "reviled denim strap"
+
+-}
+replace : Regex -> (Match -> String) -> String -> String
+replace =
+    Regex.replace All
+
+
+{-| Just like `replace` but it stops after some number of matches.
+
+A library like [`elm/parser`][parser] will probably lead to better code in
+the long run.
+
+[parser]: /packages/elm/parser/latest
+
+-}
+replaceAtMost : Int -> Regex -> (Match -> String) -> String -> String
+replaceAtMost =
+    Regex.replace << AtMost

--- a/src/String019.elm
+++ b/src/String019.elm
@@ -1,0 +1,59 @@
+module String019 exposing (replace, fromInt, fromFloat)
+
+{-| Elm 0.19 added several new functions.
+
+@docs replace, fromInt, fromFloat
+
+-}
+
+import String exposing (split, join)
+
+
+{-| Replace all occurrences of some substring.
+
+    replace "." "-" "Json.Decode.succeed" --> "Json-Decode-succeed"
+
+    replace "," "/" "a,b,c,d,e"           --> "a/b/c/d/e"
+
+**Note:** If you need more advanced replacements, check out the
+[`elm/parser`][parser] or [`elm/regex`][regex] package.
+
+[parser]: /packages/elm/parser/latest
+[regex]: /packages/elm/regex/latest
+
+-}
+replace : String -> String -> String -> String
+replace before after string =
+    join after (split before string)
+
+
+{-| Convert an `Int` to a `String`.
+
+    fromInt 123 --> "123"
+
+    fromInt -42 --> "-42"
+
+Check out [`Debug.toString`](Debug#toString) to convert *any* value to a string
+for debugging purposes.
+
+-}
+fromInt : Int -> String
+fromInt =
+    toString
+
+
+{-| Convert a `Float` to a `String`.
+
+    fromFloat 123 --> "123"
+
+    fromFloat -42 --> "-42"
+
+fromFloat 3.9 --> "3.9"
+
+Check out [`Debug.toString`](Debug#toString) to convert *any* value to a string
+for debugging purposes.
+
+-}
+fromFloat : Float -> String
+fromFloat =
+    toString

--- a/src/Time019.elm
+++ b/src/Time019.elm
@@ -1,0 +1,600 @@
+module Time019
+    exposing
+        ( Month
+        , Posix
+        , Weekday
+        , Zone
+        , ZoneName(..)
+        , customZone
+        , every
+        , getZoneName
+        , here
+        , millisToPosix
+        , now
+        , posixToMillis
+        , toDay
+        , toHour
+        , toMillis
+        , toMinute
+        , toMonth
+        , toSecond
+        , toWeekday
+        , toYear
+        , utc
+        )
+
+{-| Elm 0.19 moved the `Date` module to a separate package
+[elm-time](https://package.elm-lang.org/packages/elm/time/1.0.0/)
+and renamed it `Time`. So, this is an implementation for Elm 0.18.
+
+
+# Time
+
+@docs Posix, now, every, posixToMillis, millisToPosix
+
+
+# Time Zones
+
+@docs Zone, utc, here
+
+
+# Human Times
+
+@docs toYear, toMonth, toDay, toWeekday, toHour, toMinute, toSecond, toMillis
+
+
+# Weeks and Months
+
+@docs Weekday, Month
+
+
+# For Package Authors
+
+@docs customZone, getZoneName, ZoneName
+
+-}
+
+import Basics019 exposing (modBy)
+import Date exposing (Day(..), Month(..))
+import Task exposing (Task)
+import Time
+
+
+-- POSIX
+
+
+{-| A computer representation of time. It is the same all over Earth, so if we
+have a phone call or meeting at a certain POSIX time, there is no ambiguity.
+It is very hard for humans to _read_ a POSIX time though, so we use functions
+like [`toHour`](#toHour) and [`toMinute`](#toMinute) to `view` them.
+-}
+type Posix
+    = Posix Int
+
+
+{-| Get the POSIX time at the moment when this task is run.
+-}
+now : Task x Posix
+now =
+    Task.map (Date.toTime >> round >> millisToPosix) Date.now
+
+
+{-| Turn a `Posix` time into the number of milliseconds since 1970 January 1
+at 00:00:00 UTC. It was a Thursday.
+-}
+posixToMillis : Posix -> Int
+posixToMillis (Posix millis) =
+    millis
+
+
+{-| Turn milliseconds into a `Posix` time.
+-}
+millisToPosix : Int -> Posix
+millisToPosix =
+    Posix
+
+
+
+-- TIME ZONES
+
+
+{-| Information about a particular time zone.
+
+The [IANA Time Zone Database][iana] tracks things like UTC offsets and
+daylight-saving rules so that you can turn a `Posix` time into local times
+within a time zone.
+
+See [`utc`](#utc), [`here`](#here), and [`Browser.Env`][env] to learn how to
+obtain `Zone` values.
+
+[iana]: https://www.iana.org/time-zones
+[env]: /packages/elm/browser/latest/Browser#Env
+
+-}
+type Zone
+    = Zone Int (List Era)
+
+
+{-| Currently the public API only needs:
+
+  - `start` is the beginning of this `Era` in "minutes since the Unix Epoch"
+  - `offset` is the UTC offset of this `Era` in minutes
+    But eventually, it will make sense to have `abbr : String` for `PST` vs `PDT`
+
+-}
+type alias Era =
+    { start : Int
+    , offset : Int
+    }
+
+
+{-| The time zone for Coordinated Universal Time ([UTC])
+
+The `utc` zone has no time adjustments. It never observes daylight-saving
+time and it never shifts around based on political restructuring.
+[UTC]: <https://en.wikipedia.org/wiki/Coordinated_Universal_Time>
+
+-}
+utc : Zone
+utc =
+    Zone 0 []
+
+
+{-| Produce a `Zone` based on the current UTC offset.
+
+You can use this to figure out what day it is where you are:
+
+    import Task exposing (Task)
+
+    whatDayIsIt : Task x Int
+    whatDayIsIt =
+        Task.map2 Time.toDay Time.here Time.now
+
+**Accuracy Note:** This function can only give time zones like `Etc/GMT+9` or
+`Etc/GMT-6`. It cannot give you `Europe/Stockholm`, `Asia/Tokyo`, or any other
+normal time zone from the [full list][tz] due to limitations in JavaScript.
+For example, if you run `here` in New York City, the resulting `Zone` will
+never be `America/New_York`. Instead you get `Etc/GMT-5` or `Etc/GMT-4`
+depending on Daylight Saving Time. So even though browsers must have internal
+access to `America/New_York` to figure out that offset, there is no public API
+to get the full information. This means the `Zone` you get from this function
+will act weird if (1) an application stays open across a Daylight Saving Time
+boundary or (2) you try to use it on historical data.
+
+**Future Note:** We can improve `here` when there is good browser support for
+JavaScript functions that (1) expose the IANA time zone database and (2) let
+you ask the time zone of the computer. The committee that reviews additions to
+JavaScript is called TC39, and I encourage you to push for these capabilities! I
+cannot do it myself unfortunately.
+
+**Alternatives:** See the `customZone` docs to learn how to implement stopgaps.
+[tz]: <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
+
+-}
+here : Task x Zone
+here =
+    Task.succeed "todo"
+        |> Task.andThen Debug.crash
+
+
+
+-- DATES
+
+
+{-| What year is it?!
+
+    toYear utc (millisToPosix 0) --> 1970
+
+    toYear nyc (millisToPosix 0) == 1969
+    -- pretend `nyc` is the `Zone` for America/New_York.
+
+-}
+toYear : Zone -> Posix -> Int
+toYear zone time =
+    (toCivil (toAdjustedMinutes zone time)).year
+
+
+{-| What month is it?!
+
+    import Date exposing (Month(..))
+
+    toMonth utc (millisToPosix 0) --> Jan
+
+    toMonth nyc (millisToPosix 0) == Dec
+    -- pretend `nyc` is the `Zone` for America/New_York.
+
+-}
+toMonth : Zone -> Posix -> Month
+toMonth zone time =
+    case (toCivil (toAdjustedMinutes zone time)).month of
+        1 ->
+            Jan
+
+        2 ->
+            Feb
+
+        3 ->
+            Mar
+
+        4 ->
+            Apr
+
+        5 ->
+            May
+
+        6 ->
+            Jun
+
+        7 ->
+            Jul
+
+        8 ->
+            Aug
+
+        9 ->
+            Sep
+
+        10 ->
+            Oct
+
+        11 ->
+            Nov
+
+        _ ->
+            Dec
+
+
+{-| What day is it?! (Days go from 1 to 31)
+
+    toDay utc (millisToPosix 0) --> 1
+
+    toDay nyc (millisToPosix 0) == 31
+    -- pretend `nyc` is the `Zone` for America/New_York.
+
+-}
+toDay : Zone -> Posix -> Int
+toDay zone time =
+    (toCivil (toAdjustedMinutes zone time)).day
+
+
+{-| What day of the week is it?
+
+    toWeekday utc (millisToPosix 0) == Thu
+
+    toWeekday nyc (millisToPosix 0) == Wed
+    -- pretend `nyc` is the `Zone` for America/New_York.
+
+-}
+toWeekday : Zone -> Posix -> Weekday
+toWeekday zone time =
+    case modBy 7 (flooredDiv (toAdjustedMinutes zone time) (60 * 24)) of
+        0 ->
+            Thu
+
+        1 ->
+            Fri
+
+        2 ->
+            Sat
+
+        3 ->
+            Sun
+
+        4 ->
+            Mon
+
+        5 ->
+            Tue
+
+        _ ->
+            Wed
+
+
+{-| What hour is it? (From 0 to 23)
+
+    toHour utc (millisToPosix 0) --> 0 -- 12am
+
+    toHour nyc (millisToPosix 0) == 19 -- 7pm
+    -- pretend `nyc` is the `Zone` for America/New_York.
+
+-}
+toHour : Zone -> Posix -> Int
+toHour zone time =
+    modBy 24 (flooredDiv (toAdjustedMinutes zone time) 60)
+
+
+{-| What minute is it? (From 0 to 59)
+
+    toMinute utc (millisToPosix 0) --> 0
+
+This can be different in different time zones. Some time zones are offset
+by 30 or 45 minutes!
+
+-}
+toMinute : Zone -> Posix -> Int
+toMinute zone time =
+    modBy 60 (toAdjustedMinutes zone time)
+
+
+{-| What second is it?
+
+    toSecond utc (millisToPosix 0) --> 0
+
+    toSecond utc (millisToPosix 1234) --> 1
+
+    toSecond utc (millisToPosix 5678) --> 5
+
+-}
+toSecond : Zone -> Posix -> Int
+toSecond _ time =
+    modBy 60 (flooredDiv (posixToMillis time) 1000)
+
+
+{-|
+
+    toMillis utc (millisToPosix    0) --> 0
+
+    toMillis utc (millisToPosix 1234) --> 234
+
+    toMillis utc (millisToPosix 5678) --> 678
+
+-}
+toMillis : Zone -> Posix -> Int
+toMillis _ time =
+    modBy 1000 (posixToMillis time)
+
+
+
+-- DATE HELPERS
+
+
+toAdjustedMinutes : Zone -> Posix -> Int
+toAdjustedMinutes (Zone defaultOffset eras) time =
+    toAdjustedMinutesHelp defaultOffset (flooredDiv (posixToMillis time) 60000) eras
+
+
+toAdjustedMinutesHelp : Int -> Int -> List Era -> Int
+toAdjustedMinutesHelp defaultOffset posixMinutes eras =
+    case eras of
+        [] ->
+            posixMinutes + defaultOffset
+
+        era :: olderEras ->
+            if era.start < posixMinutes then
+                posixMinutes + era.offset
+            else
+                toAdjustedMinutesHelp defaultOffset posixMinutes olderEras
+
+
+toCivil : Int -> { year : Int, month : Int, day : Int }
+toCivil minutes =
+    let
+        rawDay =
+            flooredDiv minutes (60 * 24) + 719468
+
+        era =
+            (if rawDay >= 0 then
+                rawDay
+             else
+                rawDay - 146096
+            )
+                // 146097
+
+        dayOfEra =
+            rawDay - era * 146097
+
+        -- [0, 146096]
+        yearOfEra =
+            (dayOfEra - dayOfEra // 1460 + dayOfEra // 36524 - dayOfEra // 146096) // 365
+
+        -- [0, 399]
+        year =
+            yearOfEra + era * 400
+
+        dayOfYear =
+            dayOfEra - (365 * yearOfEra + yearOfEra // 4 - yearOfEra // 100)
+
+        -- [0, 365]
+        mp =
+            (5 * dayOfYear + 2) // 153
+
+        -- [0, 11]
+        month =
+            mp
+                + (if mp < 10 then
+                    3
+                   else
+                    -9
+                  )
+
+        -- [1, 12]
+    in
+    { year =
+        year
+            + (if month <= 2 then
+                1
+               else
+                0
+              )
+    , month = month
+    , day = dayOfYear - (153 * mp + 2) // 5 + 1 -- [1, 31]
+    }
+
+
+flooredDiv : Int -> Float -> Int
+flooredDiv numerator denominator =
+    floor (toFloat numerator / denominator)
+
+
+
+-- WEEKDAYS AND MONTHS
+
+
+{-| Represents a `Weekday` so that you can convert it to a `String` or `Int`
+however you please. For example, if you need the Japanese representation, you
+can say:
+
+    toJapaneseWeekday : Weekday -> String
+    toJapaneseWeekday weekday =
+        case weekday of
+            Mon ->
+                "月"
+
+            Tue ->
+                "火"
+
+            Wed ->
+                "水"
+
+            Thu ->
+                "木"
+
+            Fri ->
+                "金"
+
+            Sat ->
+                "土"
+
+            Sun ->
+                "日"
+
+-}
+type alias Weekday =
+    Date.Day
+
+
+{-| Represents a `Month` so that you can convert it to a `String` or `Int`
+however you please. For example, if you need the Danish representation, you
+can say:
+
+    toDanishMonth : Month -> String
+    toDanishMonth month =
+        case month of
+            Jan ->
+                "januar"
+
+            Feb ->
+                "februar"
+
+            Mar ->
+                "marts"
+
+            Apr ->
+                "april"
+
+            May ->
+                "maj"
+
+            Jun ->
+                "juni"
+
+            Jul ->
+                "juli"
+
+            Aug ->
+                "august"
+
+            Sep ->
+                "september"
+
+            Oct ->
+                "oktober"
+
+            Nov ->
+                "november"
+
+            Dec ->
+                "december"
+
+-}
+type alias Month =
+    Date.Month
+
+
+
+-- SUBSCRIPTIONS
+
+
+{-| Get the current time periodically. How often though? Well, you provide an
+interval in milliseconds (like `1000` for a second or `60 * 1000` for a minute
+or `60 * 60 * 1000` for an hour) and that is how often you get a new time!
+
+Check out [this example](https://elm-lang.org/examples/time) to see how to use
+it in an application.
+
+**This function is not for animation.** Use the [`elm/animation-frame`][af]
+package for that sort of thing! It syncs up with repaints and will end up
+being much smoother for any moving visuals.
+
+[af]: /packages/elm/animation-frame/latest
+
+-}
+every : Float -> (Posix -> msg) -> Sub msg
+every interval tagger =
+    Time.every interval (round >> millisToPosix >> tagger)
+
+
+
+-- FOR PACKAGE AUTHORS
+
+
+{-| **Intended for package authors.**
+
+The documentation of [`here`](#here) explains that it has certain accuracy
+limitations that block on adding new APIs to JavaScript. The `customZone`
+function is a stopgap that takes:
+
+1.  A default offset in minutes. So `Etc/GMT-5` is `customZone (-5 * 60) []`
+    and `Etc/GMT+9` is `customZone (9 * 60) []`.
+2.  A list of exceptions containing their `start` time in "minutes since the Unix
+    epoch" and their `offset` in "minutes from UTC"
+
+Human times will be based on the nearest `start`, falling back on the default
+offset if the time is older than all of the exceptions.
+
+When paired with `getZoneName`, this allows you to load the real IANA time zone
+database however you want: HTTP, cache, hardcode, etc.
+
+**Note:** If you use this, please share your work in an Elm community forum! I
+am sure others would like to hear about it, and more experience reports will
+help me and the any potential TC39 proposal.
+
+-}
+customZone : Int -> List { start : Int, offset : Int } -> Zone
+customZone =
+    Zone
+
+
+{-| **Intended for package authors.**
+
+Use `Intl.DateTimeFormat().resolvedOptions().timeZone` to try to get names
+like `Europe/Moscow` or `America/Havana`. From there you can look it up in any
+IANA data you loaded yourself.
+
+-}
+getZoneName : Task x ZoneName
+getZoneName =
+    Task.succeed "todo"
+        |> Task.andThen Debug.crash
+
+
+{-| **Intended for package authors.**
+
+The `getZoneName` function relies on a JavaScript API that is not supported
+in all browsers yet, so it can return the following:
+
+    -- in more recent browsers
+    Name "Europe/Moscow"
+    Name "America/Havana"
+
+    -- in older browsers
+    Offset 180
+    Offset -300
+
+So if the real info is not available, it will tell you the current UTC offset
+in minutes, just like what `here` uses to make zones like `customZone -60 []`.
+
+-}
+type ZoneName
+    = Name String
+    | Offset Int

--- a/src/Time019.elm
+++ b/src/Time019.elm
@@ -56,6 +56,7 @@ and renamed it `Time`. So, this is an implementation for Elm 0.18.
 
 import Basics019 exposing (modBy)
 import Date exposing (Day(..), Month(..))
+import Date.Extra exposing (offsetFromUtc)
 import Task exposing (Task)
 import Time
 
@@ -173,8 +174,7 @@ cannot do it myself unfortunately.
 -}
 here : Task x Zone
 here =
-    Task.succeed "todo"
-        |> Task.andThen Debug.crash
+    Task.map (offsetFromUtc >> flip customZone []) Date.now
 
 
 
@@ -574,8 +574,7 @@ IANA data you loaded yourself.
 -}
 getZoneName : Task x ZoneName
 getZoneName =
-    Task.succeed "todo"
-        |> Task.andThen Debug.crash
+    Task.map (offsetFromUtc >> Offset) Date.now
 
 
 {-| **Intended for package authors.**

--- a/src/Tuple019.elm
+++ b/src/Tuple019.elm
@@ -1,0 +1,33 @@
+module Tuple019 exposing (pair, mapBoth)
+
+{-| Elm 0.19 added `pair` and `mapBoth`.
+
+@docs pair, mapBoth
+
+-}
+
+
+{-| Create a 2-tuple.
+
+    pair 3 4 --> (3, 4)
+
+    zip : List a -> List b -> List (a, b)
+    zip xs ys =
+      List.map2 Tuple.pair xs ys
+
+-}
+pair : a -> b -> ( a, b )
+pair a b =
+    ( a, b )
+
+
+{-| Transform both parts of a tuple.
+
+    mapBoth String.reverse sqrt  ("stressed", 16) --> ("desserts", 4)
+
+    mapBoth String.length negate ("stressed", 16) --> (8, -16)
+
+-}
+mapBoth : (a -> x) -> (b -> y) -> ( a, b ) -> ( x, y )
+mapBoth funcA funcB ( x, y ) =
+    ( funcA x, funcB y )

--- a/tests/TestRandom019.elm
+++ b/tests/TestRandom019.elm
@@ -1,0 +1,74 @@
+module TestRandom019 exposing (..)
+
+import Expect
+import Fuzz exposing (Fuzzer)
+import Random exposing (Generator, Seed, initialSeed, step)
+import Random019 exposing (constant, independentSeed, lazy, uniform)
+import Test exposing (..)
+
+
+fuzzSeed : Fuzzer Seed
+fuzzSeed =
+    Fuzz.map initialSeed Fuzz.int
+
+
+testConstant : Test
+testConstant =
+    fuzz fuzzSeed "constant" <|
+        \seed ->
+            step (constant 17) seed
+                |> Expect.all
+                    [ \( value, _ ) -> Expect.equal value 17
+                    , \( _, newSeed ) -> Expect.notEqual seed newSeed
+                    ]
+
+
+probabilities : Generator (List Float)
+probabilities =
+    Random.andThen identity <|
+        uniform
+            (constant [])
+            [ Random.map2 (::)
+                (Random.float 0 1)
+                (lazy (\_ -> probabilities))
+            ]
+
+
+testLazy : Test
+testLazy =
+    -- We're just testing that lazy avoids blowing the stack
+    step probabilities (initialSeed 0)
+        |> always (test "lazy" (always Expect.pass))
+
+
+testIndependentSeed : Test
+testIndependentSeed =
+    fuzz fuzzSeed "independentSeed" <|
+        \seed ->
+            let
+                -- Given our original seed, we fork it
+                ( forked1, seed1 ) =
+                    step independentSeed seed
+
+                -- Then, we do it again (with the updated main seed)
+                ( forked2, seed2 ) =
+                    step independentSeed seed1
+
+                -- So, we should now have a bunch of seeds, all of which are
+                -- unequal. We can't directly compare seeds, but we can step
+                -- them and compare the results!
+                results =
+                    List.map
+                        (step (Random.int 0 0xFFFFFFFF) >> Tuple.first)
+                        [ seed, seed1, seed2, forked1, forked2 ]
+
+                -- For each thing in the results, count how many there are in
+                -- the list. (No doubt there is a more efficient way to do
+                -- this).
+                counts =
+                    List.map (\result -> List.length (List.filter ((==) result) results)) results
+
+                allOne =
+                    List.all ((==) 1) counts
+            in
+            Expect.true "Should be unique" allOne

--- a/tests/TestRegex019.elm
+++ b/tests/TestRegex019.elm
@@ -1,0 +1,15 @@
+module TestRegex019 exposing (..)
+
+import Expect
+import Fuzz
+import Regex
+import Regex019
+import Test exposing (..)
+
+
+testNever : Test
+testNever =
+    fuzz Fuzz.string "never" <|
+        \input ->
+            Regex.contains Regex019.never input
+                |> Expect.false ("Should not match: " ++ input)

--- a/tests/elm-doc-test.json
+++ b/tests/elm-doc-test.json
@@ -1,0 +1,7 @@
+{
+  "root": "../src",
+  "tests": [
+    "Basics019",
+    "Time019"
+  ]
+}

--- a/tests/elm-doc-test.json
+++ b/tests/elm-doc-test.json
@@ -2,6 +2,7 @@
   "root": "../src",
   "tests": [
     "Basics019",
+    "Char019",
     "Time019"
   ]
 }

--- a/tests/elm-doc-test.json
+++ b/tests/elm-doc-test.json
@@ -3,6 +3,7 @@
   "tests": [
     "Basics019",
     "Char019",
+    "Debug019",
     "Time019"
   ]
 }

--- a/tests/elm-doc-test.json
+++ b/tests/elm-doc-test.json
@@ -4,6 +4,7 @@
     "Basics019",
     "Char019",
     "Debug019",
+    "Json.Encode019",
     "String019",
     "Time019",
     "Tuple019"

--- a/tests/elm-doc-test.json
+++ b/tests/elm-doc-test.json
@@ -5,6 +5,7 @@
     "Char019",
     "Debug019",
     "String019",
-    "Time019"
+    "Time019",
+    "Tuple019"
   ]
 }

--- a/tests/elm-doc-test.json
+++ b/tests/elm-doc-test.json
@@ -4,6 +4,7 @@
     "Basics019",
     "Char019",
     "Debug019",
+    "String019",
     "Time019"
   ]
 }

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -10,7 +10,8 @@
     "exposed-modules": [],
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-community/elm-test": "4.0.0 <= v < 5.0.0"
+        "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
+        "justinmimbs/elm-date-extra": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
Essentially, this back-ports changes in Elm 0.19 so that you can use them (at least to some extent) in Elm 0.18, if you wish.